### PR TITLE
fix: enforce single-line log output & bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@gauravsharmacode/neat-logger",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "description": "Production-grade structured logger for Node.js apps using Winston",
   "author": "Neat Logger Team",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "neat-logger",
+   "name": "@gauravsharmacode/neat-logger",
+  "private": false,
   "version": "1.0.0",
   "main": "index.js",
   "description": "Production-grade structured logger for Node.js apps using Winston",
@@ -8,7 +9,7 @@
   "keywords": ["logger", "winston", "nodejs", "structured-logging"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/gauravsharmacode/neatspend-logger.git"
+    "url": "https://github.com/gauravsharmacode/neat-logger.git"
   },
   "dependencies": {
     "winston": "^3.17.0"

--- a/winstonLogger.js
+++ b/winstonLogger.js
@@ -2,29 +2,28 @@ const winston = require("winston");
 const path = require("path");
 const fs = require("fs");
 
-// Ensure log directory exists
-const LOG_DIR = path.join(process.cwd(), "logs"); // Always relative to the main project root
+const LOG_DIR = path.join(process.cwd(), "logs");
 if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR);
 
-// Define paths
 const ERROR_LOG = path.join(LOG_DIR, "error.log");
 const COMBINED_LOG = path.join(LOG_DIR, "combined.log");
 const QUERY_LOG = path.join(LOG_DIR, "query.log");
 
-// Pretty console logs
+// Force single-line console logs
 const consoleFormat = winston.format.combine(
   winston.format.colorize(),
   winston.format.timestamp(),
   winston.format.printf(({ level, message, timestamp }) => {
-    const parsed = typeof message === "object" ? message : JSON.parse(message);
-    return `[${timestamp}] ${level}: ${parsed.message} ${JSON.stringify(parsed, null, 2)}`;
+    const parsed = typeof message === "object" ? message : (() => {
+      try { return JSON.parse(message); } catch { return { message }; }
+    })();
+    return `[${timestamp}] ${level}: ${parsed.message} ${JSON.stringify(parsed)}`;
   })
 );
 
-// Raw JSON logs for file transports
 const fileFormat = winston.format.combine(
   winston.format.timestamp(),
-  winston.format.json() // auto-stringify
+  winston.format.json() // ✅ Already single-line
 );
 
 const logger = winston.createLogger({


### PR DESCRIPTION
## 🛠️ PR Title:
**fix: enforce single-line log output & bump version to 1.0.1**

---

## ✅ Description

This pull request includes the following changes:

### ✏️ Logging Format Fix
- Refactored the `winston` logger to ensure all logs are output as **single-line JSON strings**.
- Improves log readability in production and makes them easier to parse using log aggregation tools (e.g., ELK, Datadog, etc.).
- Replaced `JSON.stringify(parsed, null, 2)` with `JSON.stringify(parsed)` in the `consoleFormat`.

### 🔖 Version Bump
- Bumped version from `1.0.0` to `1.0.1` to reflect a non-breaking logging fix.
- Used `npm version patch` to follow semantic versioning.
- Git tag `v1.0.1` created automatically.

---

## 🧪 Testing

- Verified in a downstream project (`neatspend-api`) that logs now appear in a single line on both the console and in file outputs.
- Tested using sample API requests and ensured format consistency.

---

## 📦 Next Steps

- Once merged into `main`, this update (`v1.0.1`) can be published to [npm](https://www.npmjs.com/package/@gauravsharmacode/neat-logger).

